### PR TITLE
fix: disable automatic releasing of pre-releases

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -44,22 +44,6 @@ workflows:
 {{- end }}
   ### End workflows inserted by other modules
 
-  {{- if $prereleases }}
-  release_branch:
-    triggers:
-      - schedule:
-          {{- /* 15th of the month */}}
-          cron: {{ stencil.Arg "releaseOptions.prereleases.cron" | default "0 0 15 * *" }}
-          filters:
-            branches:
-              only:
-                - release
-    jobs:
-      - shared/merge:
-          head: release
-          base: main
-  {{- end }}
-
   release:
     jobs:
       ###Block(circleWorkflowJobs)


### PR DESCRIPTION
**What this PR does**: This PR disables automatic releasing of pre-releases, instead it's expected that one would release them manually. Eventually, we may end up having a Github Workflow with `workflow_dispatch` to do this instead (one click).