### PR TITLE
fix: pass node_client to release when we have a node client

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -96,6 +96,9 @@ workflows:
       # Dryrun release for PRs
       - shared/release:
           <<: *release
+          {{- if $testNodeClient }}
+          node_client: true
+          {{- end }}
           dryrun: true
           filters:
             branches:


### PR DESCRIPTION
**What this PR does**: We previously weren't building the node client when we had one which was causing release to fail