### PR TITLE
fix: Run e2e tests for non-service repos

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -1,7 +1,6 @@
 # Please re-run stencil after any changes to this file as invalid
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
-{{- $isService := stencil.Arg "service" }}
 {{- $prereleases := stencil.Arg "releaseOptions.enablePrereleases" }}
 {{- $testNodeClient := and (has "grpc" (stencil.Arg "serviceActivities")) (has "node" (stencil.Arg "grpcClients")) }}
 orbs:
@@ -129,11 +128,8 @@ workflows:
       - shared/finalize-coverage:
           context: *contexts
           requires:
-          {{- if $isService }}
             - shared/e2e
-          {{- end }}
             - shared/test
-{{- if $isService }}
       - shared/e2e:
           context: *contexts
       - shared/docker:
@@ -148,4 +144,3 @@ workflows:
                 {{- end }}
             tags:
               only: /v\d+(\.\d+)*(-.*)*/
-{{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
At some point, we started supporting running E2E tests for libraries. With the move to stencil, we accidentally removed that feature. This PR adds that feature back,

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
