### PR TITLE
feat(orb): determine orb version from devbase version

### DIFF
--- a/.circleci/scripts/render.sh
+++ b/.circleci/scripts/render.sh
@@ -27,6 +27,7 @@ arguments:
   releaseOptions:
     enablePrereleases: true
     prereleasesBranch: rc
+  # TODO(jaredallard): Remove post-release of devbase
   versions:
     devbase: dev:cache
 EOF

--- a/.circleci/scripts/render.sh
+++ b/.circleci/scripts/render.sh
@@ -19,6 +19,8 @@ cat >service.yaml <<EOF
 name: test
 modules:
   - name: github.com/getoutreach/stencil-circleci
+  - name: github.com/getoutreach/devbase
+    version: main
 replacements:
   github.com/getoutreach/stencil-circleci: 'file://$moduleDir'
 arguments:

--- a/.circleci/scripts/render.sh
+++ b/.circleci/scripts/render.sh
@@ -20,7 +20,7 @@ name: test
 modules:
   - name: github.com/getoutreach/stencil-circleci
   - name: github.com/getoutreach/devbase
-    version: main
+    channel: main
 replacements:
   github.com/getoutreach/stencil-circleci: 'file://$moduleDir'
 arguments:

--- a/.circleci/scripts/render.sh
+++ b/.circleci/scripts/render.sh
@@ -27,6 +27,8 @@ arguments:
   releaseOptions:
     enablePrereleases: true
     prereleasesBranch: rc
+  versions:
+    devbase: dev:cache
 EOF
 
 echo " 📄 Render Stencil Module"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -43,4 +43,8 @@ arguments:
       items:
         type: string
     description: gRPC clients to generate. Used to run tests on gRPC clients.
+  versions.devbase:
+    description: Version of devbase to use for the 'getoutreach/shared' orb.
+    schema:
+      type: string
 ## <</Stencil::Block>>

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -4,7 +4,7 @@ version: 2.1
 {{- $prereleases := stencil.Arg "releaseOptions.enablePrereleases" }}
 {{- $testNodeClient := and (has "grpc" (stencil.Arg "serviceActivities")) (has "node" (stencil.Arg "grpcClients")) }}
 orbs:
-  shared: getoutreach/shared@dev:cache
+  shared: getoutreach/shared@{{ stencil.Arg "versions.devbase" | default (stencil.ApplyTemplate "devbase.orb_version") }}
 
 parameters:
   rebuild_cache:

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@dev:cache
+  shared: getoutreach/shared@dev:
 
 parameters:
   rebuild_cache:

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@dev:cache
+  shared: getoutreach/shared@my-custom-version
 
 parameters:
   rebuild_cache:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,5 +1,24 @@
 {{- file.Skip "Virtual file with functions"}}
 
+# devbase.orb_version returns the version to use for devbase orb
+{{- define "devbase.orb_version" }}
+{{- $version := (.Runtime.Modules.ByName "github.com/getoutreach/devbase").Version }}
+{{- /* If we're on 'main' (the default branch) use the latest orb:  dev:first */}}
+{{- if eq $version "main" }}
+{{- "dev:first" }}
+{{- /* If we don't have a v, assume it's a branch and default to dev:<branch> */}}
+{{- else if not (hasPrefix "v" $version) }}
+{{- printf "dev:%s" $version }}
+{{- /* If we have a v and -rc. assume it's a rc version, use special tag */}}
+{{- /* Example: dev:2.6.1-rc.2 */}}
+{{- else if and (hasPrefix "v" $version) (contains "-rc." $version ) }}
+{{- printf "dev:%s" (trimPrefix "v" $version) }}
+{{- /* Otherwise this is probably a semantic-version, so just assume that */}}
+{{- else }}
+{{- trimPrefix "v" $version }}
+{{- end }}
+{{- end }}
+
 {{- define "contexts" }}
 ### Start contexts inserted by other modules
 {{- $contextsHook := (stencil.GetModuleHook "contexts") }}

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -15,7 +15,7 @@ func TestRenderAFile(t *testing.T) {
 			"prereleasesBranch": "rc",
 		},
 	})
-	st.Run(true)
+	st.Run(false)
 }
 
 func TestRenderWithSkipE2eAndDocker(t *testing.T) {
@@ -25,10 +25,13 @@ func TestRenderWithSkipE2eAndDocker(t *testing.T) {
 			"enablePrereleases": true,
 			"prereleasesBranch": "rc",
 		},
+		"versions": map[string]interface{}{
+			"devbase": "my-custom-version",
+		},
 		"ciOptions": map[string]interface{}{
 			"skipE2e":    true,
 			"skipDocker": true,
 		},
 	})
-	st.Run(true)
+	st.Run(false)
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR changes the orb version (`getoutreach/shared`) to be from the version of `devbase` in use instead of hardcoding it.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
