### PR TITLE
chore: Hotfix 8c072333ea6ebba5aaaf36d56246e5a02e68da85 into channel stable

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ name: github.com/getoutreach/stencil-circleci
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    version: ">=2.6.0-rc.3"
+    version: ">=2.7.0"
 arguments:
   coverage.provider:
     description: The platform to use for coverage reporting


### PR DESCRIPTION
Hotfixes commit "8c072333ea6ebba5aaaf36d56246e5a02e68da85" into channel stable, created by `dt release hotfix`

**DO NOT MERGE**