### PR TITLE
feat: enable release failure slack channel notifications

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,6 +11,10 @@ arguments:
       enum:
         - codecov
         - coveralls
+  notifications.releaseFailureSlackChannel:
+    schema:
+      type: string
+    description: The slack channel ID to notify when a release fails.
   releaseOptions.prereleasesBranch:
     description: See stencil-base
     schema:

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -28,9 +28,6 @@ contexts: &contexts
   {{- /* Always generate an array if there are no contexts */}}
   []
 {{- end }}
-{{- if (stencil.Arg "notifications.releaseFailureSlackChannel") }}
-  - tray-webhooks
-{{- end }}
   ## <<Stencil::Block(extraContexts)>>
 {{ $userContexts | toYaml | indent 2 }}
   ## <</Stencil::Block>>

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -28,6 +28,9 @@ contexts: &contexts
   {{- /* Always generate an array if there are no contexts */}}
   []
 {{- end }}
+{{- if (stencil.Arg "notifications.releaseFailureSlackChannel") }}
+  - tray-webhooks
+{{- end }}
   ## <<Stencil::Block(extraContexts)>>
 {{ $userContexts | toYaml | indent 2 }}
   ## <</Stencil::Block>>
@@ -142,6 +145,10 @@ workflows:
           node_client: true
           {{- end }}
           context: *contexts
+          {{- $releaseFailureSlackChannel :=  stencil.Arg "notifications.releaseFailureSlackChannel" }}
+          {{- if $releaseFailureSlackChannel }}
+          release_failure_slack_channel: {{ $releaseFailureSlackChannel }}
+          {{- end }}
           ## <<Stencil::Block(circleReleaseExtra)>>
 {{ file.Block "circleReleaseExtra" }}
           ## <</Stencil::Block>>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

There is a companion `devbase` PR that takes care of the required scripting changes.

The idea of this feature is for users to just set notifications.releaseFailureSlackChannel to the slack channel that they want to receive notifications to. Then any time the release fails, they will receive a notification to that channel.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3316]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3316]: https://outreach-io.atlassian.net/browse/DT-3316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ