### PR TITLE
chore: Promote unstable to rc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@
 
 ## Building and Testing
 
+This project uses devbase, which exposes the following build tooling: [devbase/docs/makefile.md](https://github.com/getoutreach/devbase/blob/main/docs/makefile.md)
+
 <!-- <<Stencil::Block(customBuildingAndTesting)>> -->
 
 <!-- <</Stencil::Block>> -->

--- a/monitoring/slos.tf
+++ b/monitoring/slos.tf
@@ -1,0 +1,5 @@
+
+
+// <<Stencil::Block(tfCustomSLODatadog)>>
+
+// <</Stencil::Block>>

--- a/service.yaml
+++ b/service.yaml
@@ -11,8 +11,12 @@ arguments:
     skipE2e: true
 modules:
   - name: github.com/getoutreach/stencil-template-base
+    channel: rc
   - name: github.com/getoutreach/stencil-circleci
+    channel: rc
   - name: github.com/getoutreach/devbase
+    channel: rc
+  - name: github.com/getoutreach/stencil-golang
     channel: rc
 replacements:
   github.com/getoutreach/stencil-circleci: ./

--- a/stencil.lock
+++ b/stencil.lock
@@ -5,16 +5,16 @@ modules:
       version: v2.9.0-rc.3
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
-      version: v0.7.3
+      version: v0.8.0-rc.1
     - name: github.com/getoutreach/stencil-circleci
       url: file://./
       version: local
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
-      version: v1.6.2
+      version: v1.7.0-rc.1
     - name: github.com/getoutreach/stencil-template-base
       url: https://github.com/getoutreach/stencil-template-base
-      version: v0.4.5
+      version: v0.5.0-rc.2
 files:
     - name: .circleci/config.yml
       template: .circleci/config.yml.tpl
@@ -79,6 +79,9 @@ files:
     - name: manifest.yaml
       template: manifest.yaml.tpl
       module: github.com/getoutreach/stencil-template-base
+    - name: monitoring/slos.tf
+      template: monitoring/slos.tf.tpl
+      module: github.com/getoutreach/stencil-golang
     - name: package.json
       template: package.json.tpl
       module: github.com/getoutreach/stencil-base


### PR DESCRIPTION
Promote unstable to rc, created by `dt release promote`

**DO NOT MERGE**