### PR TITLE
feat: add queue orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@dev:2.9.0-rc.3
+  shared: getoutreach/shared@dev:2.9.0-rc.4
+  queue: eddiewebb/queue@1.8.4
 
 parameters:
   rebuild_cache:

--- a/.circleci/scripts/render.sh
+++ b/.circleci/scripts/render.sh
@@ -20,7 +20,7 @@ name: test
 modules:
   - name: github.com/getoutreach/stencil-circleci
   - name: github.com/getoutreach/devbase
-    channel: main
+    channel: rc
 replacements:
   github.com/getoutreach/stencil-circleci: 'file://$moduleDir'
 arguments:

--- a/service.yaml
+++ b/service.yaml
@@ -15,7 +15,6 @@ modules:
   - name: github.com/getoutreach/stencil-circleci
     channel: rc
   - name: github.com/getoutreach/devbase
-    channel: rc
   - name: github.com/getoutreach/stencil-golang
     channel: rc
 replacements:

--- a/service.yaml
+++ b/service.yaml
@@ -15,6 +15,7 @@ modules:
   - name: github.com/getoutreach/stencil-circleci
     channel: rc
   - name: github.com/getoutreach/devbase
+    channel: rc
   - name: github.com/getoutreach/stencil-golang
     channel: rc
 replacements:

--- a/stencil.lock
+++ b/stencil.lock
@@ -2,19 +2,22 @@ version: v1.29.0
 modules:
     - name: github.com/getoutreach/devbase
       url: https://github.com/getoutreach/devbase
-      version: v2.9.0-rc.3
+      version: v2.9.0-rc.4
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
-      version: v0.8.0-rc.1
+      version: v0.8.0-rc.2
     - name: github.com/getoutreach/stencil-circleci
       url: file://./
       version: local
+    - name: github.com/getoutreach/stencil-discovery
+      url: https://github.com/getoutreach/stencil-discovery
+      version: v1.3.3
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
-      version: v1.7.0-rc.1
+      version: v1.7.0-rc.2
     - name: github.com/getoutreach/stencil-template-base
       url: https://github.com/getoutreach/stencil-template-base
-      version: v0.5.0-rc.2
+      version: v0.5.0-rc.3
 files:
     - name: .circleci/config.yml
       template: .circleci/config.yml.tpl

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -5,6 +5,7 @@ version: 2.1
 {{- $testNodeClient := and (has "grpc" (stencil.Arg "serviceActivities")) (has "node" (stencil.Arg "grpcClients")) }}
 orbs:
   shared: getoutreach/shared@{{ stencil.Arg "versions.devbase" | default (stencil.ApplyTemplate "devbase.orb_version") }}
+  queue: eddiewebb/queue@1.8.4
 
 parameters:
   rebuild_cache:

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -3,6 +3,7 @@
 version: 2.1
 orbs:
   shared: getoutreach/shared@dev:2.9.0-rc.4
+  queue: eddiewebb/queue@1.8.4
 
 parameters:
   rebuild_cache:

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -3,6 +3,7 @@
 version: 2.1
 orbs:
   shared: getoutreach/shared@my-custom-version
+  queue: eddiewebb/queue@1.8.4
 
 parameters:
   rebuild_cache:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This adds the use of a queue orb that allows us to control concurrency between workflows and specific jobs

Prerequisite for this PR: https://github.com/getoutreach/stencil-outreach/pull/99


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3222]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3222]: https://outreach-io.atlassian.net/browse/DT-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ