### PR TITLE
fix: align with stencil-actions

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -11,10 +11,10 @@ arguments:
       enum:
         - codecov
         - coveralls
-  notifications.releaseFailureSlackChannel:
+  notifications.slackChannel:
     schema:
       type: string
-    description: The slack channel ID to notify when a release fails.
+    description: The slack channel notify for build and release failures.
   releaseOptions.prereleasesBranch:
     description: See stencil-base
     schema:

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -143,9 +143,9 @@ workflows:
           node_client: true
           {{- end }}
           context: *contexts
-          {{- $releaseFailureSlackChannel :=  stencil.Arg "notifications.releaseFailureSlackChannel" }}
+          {{- $releaseFailureSlackChannel :=  stencil.Arg "notifications.slackChannel" }}
           {{- if $releaseFailureSlackChannel }}
-          release_failure_slack_channel: {{ $releaseFailureSlackChannel }}
+          release_failure_slack_channel: "{{ $releaseFailureSlackChannel }}"
           {{- end }}
           ## <<Stencil::Block(circleReleaseExtra)>>
 {{ file.Block "circleReleaseExtra" }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This updates the release notification to use the same notifications channel as the brokenbranch job in `stencil-actions`.

It also allows using a slack channel prefixed with `#`. e.g. `#dt-notifications`.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3095](https://outreach-io.atlassian.net/browse/DT-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3095]: https://outreach-io.atlassian.net/browse/DT-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ