### PR TITLE
fix: always publish docs on commits to main branch

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -175,7 +175,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - {{ .Git.DefaultBranch }}
       {{- if not (stencil.Arg "ciOptions.skipE2e") }}
       - shared/e2e:
           context: *contexts

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -174,9 +174,7 @@ workflows:
           context: *contexts
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+              - main
       {{- if not (stencil.Arg "ciOptions.skipE2e") }}
       - shared/e2e:
           context: *contexts

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -174,7 +174,8 @@ workflows:
           context: *contexts
           filters:
             branches:
-              - main
+              only:
+                - main
       {{- if not (stencil.Arg "ciOptions.skipE2e") }}
       - shared/e2e:
           context: *contexts

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -116,9 +116,8 @@ workflows:
           context: *contexts
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+              only:
+                - main
       - shared/e2e:
           context: *contexts
           ## <<Stencil::Block(circleE2EExtra)>>

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -117,7 +117,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - 
       - shared/e2e:
           context: *contexts
           ## <<Stencil::Block(circleE2EExtra)>>

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -117,5 +117,5 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - 
 )

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -116,7 +116,6 @@ workflows:
           context: *contexts
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+              only:
+                - main
 )


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Based on feedback:
Often docs are updated with the semantic commit of `chore:` and that doesn't cut a release on repos. 
Changing the behavior of this job to run on `main` makes `chore: update docs` usable.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3205]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3205]: https://outreach-io.atlassian.net/browse/DT-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ