### PR TITLE
fix: specify rc version in manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ name: github.com/getoutreach/stencil-circleci
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    channel: rc
+    version: ">=v2.9.0-rc.12"
 arguments:
   coverage.provider:
     description: The platform to use for coverage reporting

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@dev:2.9.0-rc.6
+  shared: getoutreach/shared@dev:2.9.0-rc.12
   queue: eddiewebb/queue@1.8.4
 
 parameters:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Fixes a conflict between stencil-base and stencil-circleci providing conflicting versions.
Related PR: https://github.com/getoutreach/stencil-base/pull/93

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3489]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3489]: https://outreach-io.atlassian.net/browse/DT-3489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ