### PR TITLE
chore: Promote unstable to rc

### DIFF
--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.9.0
+  shared: getoutreach/shared@dev:2.10.0-rc.5
   queue: eddiewebb/queue@1.8.4
 
 parameters:


### PR DESCRIPTION
Promote unstable to rc, created by `dt release promote`

**DO NOT MERGE**