### PR TITLE
fix(docs): publish on default branch and tags

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -176,6 +176,8 @@ workflows:
             branches:
               only:
                 - {{ .Git.DefaultBranch }}
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
       {{- if not (stencil.Arg "ciOptions.skipE2e") }}
       - shared/e2e:
           context: *contexts

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -118,6 +118,8 @@ workflows:
             branches:
               only:
                 - 
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
       - shared/e2e:
           context: *contexts
           ## <<Stencil::Block(circleE2EExtra)>>

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -118,4 +118,6 @@ workflows:
             branches:
               only:
                 - 
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
 )


### PR DESCRIPTION
**What this PR does**: This PR changes the publish logic to run only on the branch main but also on all semver tags. Without this change, service documentation has not been being published to engdocs.