### PR TITLE
fix(manifest): remove rc dependency of devbase

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,6 @@ name: github.com/getoutreach/stencil-circleci
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    version: ">=v2.9.0-rc.12"
 arguments:
   coverage.provider:
     description: The platform to use for coverage reporting


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Removes an rc requirement of stencil-circleci, this should help ensure we don't accidentally always pull rc versions of devbase in the dependency tree.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
