### PR TITLE
fix: allow extra props of shared/test

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -170,7 +170,11 @@ workflows:
           filters:
             branches:
               ignore: *release_branches
-      - shared/test: *test
+      - shared/test:
+          <<: *test
+          ## <<Stencil::Block(circleSharedTestExtra)>>
+{{ file.Block "circleSharedTestExtra" }}
+          ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
           filters:

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.11.0
+  shared: getoutreach/shared@2.12.0
   queue: eddiewebb/queue@1.8.4
 
 parameters:
@@ -111,7 +111,11 @@ workflows:
           filters:
             branches:
               ignore: *release_branches
-      - shared/test: *test
+      - shared/test:
+          <<: *test
+          ## <<Stencil::Block(circleSharedTestExtra)>>
+
+          ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
           filters:

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -111,7 +111,11 @@ workflows:
           filters:
             branches:
               ignore: *release_branches
-      - shared/test: *test
+      - shared/test:
+          <<: *test
+          ## <<Stencil::Block(circleSharedTestExtra)>>
+
+          ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
           filters:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
I want to increase `no_output_timeout` of the `shared/test` but it does not have a block to add extra properties. If I add it to the existing `test` block, since it is used in save_cache/rebuild_cache jobs, CI fails to accept it.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[CDT-00]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
