### PR TITLE
test: update snapshot to devbase 2.19.2

### DIFF
--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.19.0
+  shared: getoutreach/shared@2.19.2
   queue: eddiewebb/queue@2.2.1
 
 parameters:


### PR DESCRIPTION
## What this PR does / why we need it

Unbreaks the tests. There will be a follow-up PR to make it less brittle.