### PR TITLE
fix: Use the latest orb version for devbase local

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -3,8 +3,8 @@
 # devbase.orb_version returns the version to use for devbase orb
 {{- define "devbase.orb_version" }}
 {{- $version := (.Runtime.Modules.ByName "github.com/getoutreach/devbase").Version }}
-{{- /* If we're on 'main' (the default branch) use the latest orb:  dev:first */}}
-{{- if eq $version "main" }}
+{{- /* If we're on 'main' (the default branch) or use local version of devbase, use the latest orb:  dev:first */}}
+{{- if or (eq $version "main") (eq $version "local")}}
 {{- "dev:first" }}
 {{- /* If we don't have a v, assume it's a branch and default to dev:<branch> */}}
 {{- else if not (hasPrefix "v" $version) }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Use the latest orb version when the devbase is set to local version.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3834]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3834]: https://outreach-io.atlassian.net/browse/DT-3834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ