### PR TITLE
feat: use separate job to build ARM64 Docker image

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,6 +2,7 @@ name: github.com/getoutreach/stencil-circleci
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
+    version: ">=2.22.0-rc.1"
 arguments:
   coverage.provider:
     description: The platform to use for coverage reporting

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -191,7 +191,24 @@ workflows:
           ## <</Stencil::Block>>
       {{- end }}
       {{- if not (stencil.Arg "ciOptions.skipDocker") }}
-      - shared/docker:
+      - shared/docker_stitch:
+          context: *contexts
+          requires:
+            - shared/docker_amd64
+            - shared/docker_arm64
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/docker_amd64:
+          context: *contexts
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/docker_arm64:
           context: *contexts
           filters:
             branches:

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.20.0
+  shared: getoutreach/shared@dev:2.22.0-rc.1
   queue: eddiewebb/queue@2.2.1
 
 parameters:
@@ -127,7 +127,24 @@ workflows:
           ## <<Stencil::Block(circleE2EExtra)>>
 
           ## <</Stencil::Block>>
-      - shared/docker:
+      - shared/docker_stitch:
+          context: *contexts
+          requires:
+            - shared/docker_amd64
+            - shared/docker_arm64
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/docker_amd64:
+          context: *contexts
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/docker_arm64:
           context: *contexts
           filters:
             branches:


### PR DESCRIPTION
## What this PR does / why we need it

Replaces the old `shared/docker` job with three jobs to build Docker images on their respective native arch. See https://github.com/getoutreach/devbase/pull/691 for details.

## Jira ID

[DT-3606]

[DT-3606]: https://outreach-io.atlassian.net/browse/DT-3606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ