### PR TITLE
chore(manifest): depend on a stable version of devbase

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ name: github.com/getoutreach/stencil-circleci
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    version: ">=2.22.0-rc.1"
+    version: ">=2.22.0"
 arguments:
   coverage.provider:
     description: The platform to use for coverage reporting

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@dev:2.22.0-rc.1
+  shared: getoutreach/shared@2.22.0
   queue: eddiewebb/queue@2.2.1
 
 parameters:


### PR DESCRIPTION
## What this PR does / why we need it

This will prevent folks from resolving stencil updates in the RC channel.