### PR TITLE
fix(orb): don't hardcode orb name in Makefile

### DIFF
--- a/templates/Makefile.tpl
+++ b/templates/Makefile.tpl
@@ -14,7 +14,7 @@ validate-orb: build-orb
 
 .PHONY: publish-orb
 publish-orb: validate-orb
-	circleci orb publish orb.yml getoutreach/shared@dev:$(ORB_DEV_TAG)
+	circleci orb publish orb.yml {{ stencil.Arg "releaseOptions.orbName" }}@dev:$(ORB_DEV_TAG)
 {{- end }}
 
 {{- if stencil.Arg "releaseOptions.publishOrb" }}


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.