### PR TITLE
fix(prerelease): populate blocks correctly

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -208,12 +208,12 @@ workflows:
           dryrun: false
           context: *contexts
           release_failure_slack_channel: {{ $releaseFailureSlackChannel }}
-          ## <<Stencil::Block(circleReleaseExtra)>>
-
+          ## <<Stencil::Block(circlePreReleaseExtra)>>
+{{ file.Block "circlePreReleaseExtra" }}
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
-
+            ## <<Stencil::Block(circlePreReleaseRequires)>>
+{{ file.Block "circlePreReleaseRequires" }}
             ## <</Stencil::Block>>
             - shared/test
           filters:
@@ -225,12 +225,12 @@ workflows:
       - shared/pre-release: &pre-release
           dryrun: true
           context: *contexts
-          ## <<Stencil::Block(circleReleaseExtra)>>
-
+          ## <<Stencil::Block(circlePreReleaseDryRunExtra)>>
+{{ file.Block "circlePreReleaseDryRunExtra" }}
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
-
+            ## <<Stencil::Block(circlePreReleaseDryRunRequires)>>
+{{ file.Block "circlePreReleaseDryRunRequires" }}
             ## <</Stencil::Block>>
             - shared/test
           filters:

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -128,11 +128,11 @@ workflows:
           dryrun: false
           context: *contexts
           release_failure_slack_channel: 
-          ## <<Stencil::Block(circleReleaseExtra)>>
+          ## <<Stencil::Block(circlePreReleaseExtra)>>
 
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
+            ## <<Stencil::Block(circlePreReleaseRequires)>>
 
             ## <</Stencil::Block>>
             - shared/test
@@ -144,11 +144,11 @@ workflows:
       - shared/pre-release: &pre-release
           dryrun: true
           context: *contexts
-          ## <<Stencil::Block(circleReleaseExtra)>>
+          ## <<Stencil::Block(circlePreReleaseDryRunExtra)>>
 
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
+            ## <<Stencil::Block(circlePreReleaseDryRunRequires)>>
 
             ## <</Stencil::Block>>
             - shared/test

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -115,11 +115,11 @@ workflows:
       - shared/pre-release: &pre-release
           dryrun: true
           context: *contexts
-          ## <<Stencil::Block(circleReleaseExtra)>>
+          ## <<Stencil::Block(circlePreReleaseDryRunExtra)>>
 
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
+            ## <<Stencil::Block(circlePreReleaseDryRunRequires)>>
 
             ## <</Stencil::Block>>
             - shared/test

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -116,11 +116,11 @@ workflows:
       - shared/pre-release: &pre-release
           dryrun: true
           context: *contexts
-          ## <<Stencil::Block(circleReleaseExtra)>>
+          ## <<Stencil::Block(circlePreReleaseDryRunExtra)>>
 
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
+            ## <<Stencil::Block(circlePreReleaseDryRunRequires)>>
 
             ## <</Stencil::Block>>
             - shared/test

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -116,11 +116,11 @@ workflows:
       - shared/pre-release: &pre-release
           dryrun: true
           context: *contexts
-          ## <<Stencil::Block(circleReleaseExtra)>>
+          ## <<Stencil::Block(circlePreReleaseDryRunExtra)>>
 
           ## <</Stencil::Block>>
           requires:
-            ## <<Stencil::Block(circleReleaseRequires)>>
+            ## <<Stencil::Block(circlePreReleaseDryRunRequires)>>
 
             ## <</Stencil::Block>>
             - shared/test


### PR DESCRIPTION
## What this PR does / why we need it

This sets the pre-release and pre-release dry run blocks correctly.