### PR TITLE
fix: extra params and notification to prelease jobs

### DIFF
--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -95,12 +95,18 @@ workflows:
     jobs:
       - shared/trigger_rc_release:
           context: *contexts
+          ## <<Stencil::Block(circleAutoTriggerRCExtra)>>
+
+          ## <</Stencil::Block>>
 
   manual-release-rc:
     when: << pipeline.parameters.release_rc>>
     jobs:
       - shared/trigger_rc_release:
           context: *contexts
+          ## <<Stencil::Block(circleManualTriggerRCExtra)>>
+
+          ## <</Stencil::Block>>
 
   release:
     when:
@@ -130,7 +136,6 @@ workflows:
       - shared/pre-release: &pre-release
           dryrun: false
           context: *contexts
-          release_failure_slack_channel: 
           ## <<Stencil::Block(circlePreReleaseExtra)>>
 
           ## <</Stencil::Block>>

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -89,6 +89,9 @@ workflows:
     jobs:
       - shared/trigger_rc_release:
           context: *contexts
+          ## <<Stencil::Block(circleManualTriggerRCExtra)>>
+
+          ## <</Stencil::Block>>
 
   release:
     when:

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -89,6 +89,9 @@ workflows:
     jobs:
       - shared/trigger_rc_release:
           context: *contexts
+          ## <<Stencil::Block(circleManualTriggerRCExtra)>>
+
+          ## <</Stencil::Block>>
 
   release:
     when:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Add extra params blocks, and failure notifrication for trigger-rc-release job, make it configurable to larger instance. 
Example of [failed job](https://app.circleci.com/pipelines/github/getoutreach/devenv/4356/workflows/1452d78c-0bc3-449f-a68d-24b5667a3a59/jobs/12912).

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
