### PR TITLE
fix: use double quotes in ci config

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -70,17 +70,17 @@ release_branches: &release_branches
   # Release branch
   - release
   # Pre-releases branch
-  - {{ default $defaultBranch $pb | squote }}
+  - {{ default $defaultBranch $pb | quote }}
     {{- /*
       If we have a pre-release branch set, but it's not the
       default branch we need to include the default branch
       */}}
     {{- if and $pb (ne $pb $defaultBranch) }}
   # Unstable branch, e.g. HEAD development
-  - {{ $defaultBranch | squote }}
+  - {{ $defaultBranch | quote }}
     {{- end }}
   {{- else }}
-  - {{ $defaultBranch | squote }}
+  - {{ $defaultBranch | quote }}
   {{- end }}
 
 jobs: {{ if and (empty (file.Block "circleJobs")) (empty (stencil.GetModuleHook "jobs")) }} {} {{ end }}

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -48,7 +48,7 @@ release_branches: &release_branches
   # Release branch
   - release
   # Pre-releases branch
-  - 'main'
+  - "main"
 
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -42,7 +42,7 @@ test: &test
 
 # Branches used for releasing code, pre-release or not
 release_branches: &release_branches
-  - 'main'
+  - "main"
 
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -42,7 +42,7 @@ test: &test
 
 # Branches used for releasing code, pre-release or not
 release_branches: &release_branches
-  - 'main'
+  - "main"
 
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -42,7 +42,7 @@ test: &test
 
 # Branches used for releasing code, pre-release or not
 release_branches: &release_branches
-  - 'main'
+  - "main"
 
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -48,7 +48,7 @@ release_branches: &release_branches
   # Release branch
   - release
   # Pre-releases branch
-  - 'main'
+  - "main"
 
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -48,7 +48,7 @@ release_branches: &release_branches
   # Release branch
   - release
   # Pre-releases branch
-  - 'main'
+  - "main"
 
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Replace single quotes by double quotes.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
