### PR TITLE
feat: add block to add extra anchors

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -86,6 +86,10 @@ release_branches: &release_branches
   - {{ $defaultBranch | quote }}
   {{- end }}
 
+## <<Stencil::Block(circleAnchorExtra)>>
+{{ file.Block "circleAnchorExtra" }}
+## <</Stencil::Block>>
+
 jobs: {{ if and (empty (file.Block "circleJobs")) (empty (stencil.GetModuleHook "jobs")) }} {} {{ end }}
   ## <<Stencil::Block(circleJobs)>>
 {{ file.Block "circleJobs" }}

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -53,6 +53,10 @@ release_branches: &release_branches
   # Pre-releases branch
   - "main"
 
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>
 

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.28.1
+  shared: getoutreach/shared@2.28.2
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.28.1
+  shared: getoutreach/shared@2.28.2
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -47,6 +47,10 @@ test: &test
 release_branches: &release_branches
   - "main"
 
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>
 

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.28.1
+  shared: getoutreach/shared@2.28.2
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -47,6 +47,10 @@ test: &test
 release_branches: &release_branches
   - "main"
 
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>
 

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -47,6 +47,10 @@ test: &test
 release_branches: &release_branches
   - "main"
 
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>
 

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -53,6 +53,10 @@ release_branches: &release_branches
   # Pre-releases branch
   - "main"
 
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>
 

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.28.1
+  shared: getoutreach/shared@2.28.2
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -53,6 +53,10 @@ release_branches: &release_branches
   # Pre-releases branch
   - "main"
 
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
 jobs:  {} 
   ## <<Stencil::Block(circleJobs)>>
 


### PR DESCRIPTION
## What this PR does / why we need it

Adds an extra YAML anchor block to define custom blocks such as

```yaml
## <<Stencil::Block(circleAnchorExtra)>>
foo_steps: &foo_steps
  - run: echo foo
## <</Stencil::Block>>

# [...]

steps:
  <<: *foo_steps
  # [...] more steps
```

## Notes for your reviewers

Also fixes the tests by updating the orb version.