### PR TITLE
fix(nodejs): add support for ECR executors for test client job

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -6,6 +6,12 @@ version: 2.1
 {{- $testNodeClient := and (or (not (stencil.Arg "service")) (has "grpc" (stencil.Arg "serviceActivities"))) (has "node" (stencil.Arg "grpcClients")) }}
 {{- $defaultBranch := .Git.DefaultBranch | default "main" }}
 {{- $releaseFailureSlackChannel :=  stencil.Arg "notifications.slackChannel" }}
+{{- $executorName := "" }}
+{{- if contains "amazonaws.com" .Runtime.Box.Docker.ImagePullRegistry }}
+{{- $executorName = "shared/testbed-docker-aws" }}
+{{- else }}
+{{- $executorName = "shared/testbed-docker" }}
+{{- end }}
 orbs:
   shared: getoutreach/shared@{{ stencil.Arg "versions.devbase" | default (stencil.ApplyTemplate "devbase.orb_version") }}
   queue: eddiewebb/queue@2.2.1
@@ -192,6 +198,8 @@ workflows:
       {{- if $testNodeClient }}
       - shared/test_node_client:
           context: *contexts
+          docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
+          executor_name: {{ $executorName }}
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
 {{ file.Block "testNodeClientSteps" | default "[]" | fromYaml | toYaml | indent 12 }}

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -8,9 +8,9 @@ version: 2.1
 {{- $releaseFailureSlackChannel :=  stencil.Arg "notifications.slackChannel" }}
 {{- $executorName := "" }}
 {{- if contains "amazonaws.com" .Runtime.Box.Docker.ImagePullRegistry }}
-{{- $executorName = "shared/testbed-docker-aws" }}
+{{- $executorName = "testbed-docker-aws" }}
 {{- else }}
-{{- $executorName = "shared/testbed-docker" }}
+{{- $executorName = "testbed-docker" }}
 {{- end }}
 orbs:
   shared: getoutreach/shared@{{ stencil.Arg "versions.devbase" | default (stencil.ApplyTemplate "devbase.orb_version") }}

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -275,6 +275,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
+          executor_name: {{ $executorName }}
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -178,6 +178,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.29.0
+  shared: getoutreach/shared@2.29.4
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -132,6 +132,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.29.0
+  shared: getoutreach/shared@2.29.4
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -132,6 +132,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.29.0
+  shared: getoutreach/shared@2.29.4
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -99,7 +99,7 @@ workflows:
       - shared/test_node_client:
           context: *contexts
           docker_image: registry.example.com/foo/bootstrap/ci-slim
-          executor_name: shared/testbed-docker
+          executor_name: testbed-docker
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
             []

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -146,6 +146,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -98,8 +98,8 @@ workflows:
       ### End jobs inserted by other modules
       - shared/test_node_client:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
-          executor_name: shared/testbed-docker
+          docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
+          executor_name: shared/testbed-docker-aws
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
             []

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -146,6 +146,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker-aws
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -99,7 +99,7 @@ workflows:
       - shared/test_node_client:
           context: *contexts
           docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
-          executor_name: shared/testbed-docker-aws
+          executor_name: testbed-docker-aws
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
             []

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -163,6 +163,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker
           filters:
             branches:
               only:

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.29.0
+  shared: getoutreach/shared@2.29.4
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -163,6 +163,8 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          docker_image: registry.example.com/foo/bootstrap/ci-slim
+          executor_name: testbed-docker
           filters:
             branches:
               only:

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -1,12 +1,34 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/getoutreach/stencil/pkg/stenciltest"
 )
 
-// Replace this with your own tests.
+// fakeDockerPullRegistry sets the BOX_DOCKER_PULL_IMAGE_REGISTRY environment
+// variable to a fake value for the duration of the test.
+func fakeDockerPullRegistry(t *testing.T) {
+	t.Helper()
+	oldRegistryValue := os.Getenv("BOX_DOCKER_PULL_IMAGE_REGISTRY")
+	os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", "registry.example.com/foo")
+	t.Cleanup(func() {
+		os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", oldRegistryValue)
+	})
+}
+
+// fakeECRPullRegistry sets the BOX_DOCKER_PULL_IMAGE_REGISTRY environment
+// variable to a fake ECR value for the duration of the test.
+func fakeECRPullRegistry(t *testing.T) {
+	t.Helper()
+	oldRegistryValue := os.Getenv("BOX_DOCKER_PULL_IMAGE_REGISTRY")
+	os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", "registry.example.amazonaws.com/foo")
+	t.Cleanup(func() {
+		os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", oldRegistryValue)
+	})
+}
+
 func TestRenderAFile(t *testing.T) {
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
@@ -54,6 +76,22 @@ func TestConfigForDisabledPrereleaseWithAutoPrerelease(t *testing.T) {
 }
 
 func TestConfigForLibraryWithNodeJSGRPCClient(t *testing.T) {
+	fakeDockerPullRegistry(t)
+	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"grpcClients": []interface{}{
+			"node",
+		},
+		"service": false,
+		"versions": map[string]interface{}{
+			"devbase": "my-custom-version",
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestConfigForLibraryWithNodeJSGRPCClientAndECR(t *testing.T) {
+	fakeECRPullRegistry(t)
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
 		"grpcClients": []interface{}{

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -30,6 +30,7 @@ func fakeECRPullRegistry(t *testing.T) {
 }
 
 func TestRenderAFile(t *testing.T) {
+	fakeDockerPullRegistry(t)
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
 		"releaseOptions": map[string]interface{}{
@@ -41,6 +42,7 @@ func TestRenderAFile(t *testing.T) {
 }
 
 func TestConfigForAutoPrerelease(t *testing.T) {
+	fakeDockerPullRegistry(t)
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
 		"releaseOptions": map[string]interface{}{
@@ -53,6 +55,7 @@ func TestConfigForAutoPrerelease(t *testing.T) {
 }
 
 func TestConfigForDisabledPrerelease(t *testing.T) {
+	fakeDockerPullRegistry(t)
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
 		"releaseOptions": map[string]interface{}{
@@ -64,6 +67,7 @@ func TestConfigForDisabledPrerelease(t *testing.T) {
 }
 
 func TestConfigForDisabledPrereleaseWithAutoPrerelease(t *testing.T) {
+	fakeDockerPullRegistry(t)
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
 		"releaseOptions": map[string]interface{}{
@@ -106,6 +110,7 @@ func TestConfigForLibraryWithNodeJSGRPCClientAndECR(t *testing.T) {
 }
 
 func TestRenderWithSkipE2eAndDocker(t *testing.T) {
+	fakeDockerPullRegistry(t)
 	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{
 		"releaseOptions": map[string]interface{}{


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

## Jira ID

[DT-4466]

## TODO

- Merge https://github.com/getoutreach/devbase/pull/878
- Merge this PR
- Make an RC for `devbase`
- Make an RC for `stencil-circleci` (this repo)
- Test with a (test) service which uses the Node.js gRPC client and RC stencil modules
- Make stable releases for `devbase` and `stencil-circleci`

[DT-4466]: https://outreach-io.atlassian.net/browse/DT-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ