### PR TITLE
fix: explicitly specify executor / docker image for tests / cache jobs

### DIFF
--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -58,6 +58,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: {{ .Config.Name }}
+  docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
+  executor_name: {{ $executorName }}
   ### Start parameters inserted by other modules
   {{- /* [][]interface{} */}}
   {{- $testParametersHook := (stencil.GetModuleHook "workflows.release.jobs.test.parameters") }}

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -40,6 +40,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,6 +37,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,6 +37,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,6 +37,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,6 +37,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker-aws
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -40,6 +40,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -40,6 +40,8 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
+  docker_image: registry.example.com/foo/bootstrap/ci-slim
+  executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
   ## <<Stencil::Block(circleTestExtra)>>


### PR DESCRIPTION
## What this PR does / why we need it

Follow-up to https://github.com/getoutreach/devbase/pull/881, so that `shared/save_cache` works again.

## Jira ID

[DT-4466]

[DT-4466]: https://outreach-io.atlassian.net/browse/DT-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ