### PR TITLE
fix: avoid using non-default executors/images for OSS repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.29.0
+  shared: getoutreach/shared@dev:2.31.0-rc.1
   queue: eddiewebb/queue@2.2.1
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 
@@ -58,7 +58,7 @@ jobs:
   ## <<Stencil::Block(circleJobs)>>
   render:
     executor:
-      name: shared/testbed-docker
+      name: shared/testbed-docker-aws
     steps:
       - shared/setup_environment
       - run:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -29,6 +29,10 @@ arguments:
     schema:
       type: string
     description: The slack channel notify for build and release failures.
+  oss:
+    schema:
+      type: boolean
+    description: See stencil-base
   releaseOptions.enablePrereleases:
     description: Enables pre-releasing via semantic-release
     schema:

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -15,6 +15,10 @@ version: 2.1
 orbs:
   shared: getoutreach/shared@{{ stencil.Arg "versions.devbase" | default (stencil.ApplyTemplate "devbase.orb_version") }}
   queue: eddiewebb/queue@2.2.1
+  {{- $orbsHook := (stencil.GetModuleHook "orbs") }}
+  {{- range $orbsHook }}
+{{ toYaml . | indent 2 }}
+  {{- end }}
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 {{ file.Block "CircleCIExtraOrbs" }}
   ## <</Stencil::Block>>
@@ -58,8 +62,10 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: {{ .Config.Name }}
+  {{- if not (stencil.Arg "oss") }}
   docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
   executor_name: {{ $executorName }}
+  {{- end }}
   ### Start parameters inserted by other modules
   {{- /* [][]interface{} */}}
   {{- $testParametersHook := (stencil.GetModuleHook "workflows.release.jobs.test.parameters") }}
@@ -200,8 +206,10 @@ workflows:
       {{- if $testNodeClient }}
       - shared/test_node_client:
           context: *contexts
+          {{- if not (stencil.Arg "oss") }}
           docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
           executor_name: {{ $executorName }}
+          {{- end }}
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
 {{ file.Block "testNodeClientSteps" | default "[]" | fromYaml | toYaml | indent 12 }}
@@ -277,8 +285,10 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
+          {{- if not (stencil.Arg "oss") }}
           docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
           executor_name: {{ $executorName }}
+          {{- end }}
           filters:
             branches:
               only:

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -15,10 +15,6 @@ version: 2.1
 orbs:
   shared: getoutreach/shared@{{ stencil.Arg "versions.devbase" | default (stencil.ApplyTemplate "devbase.orb_version") }}
   queue: eddiewebb/queue@2.2.1
-  {{- $orbsHook := (stencil.GetModuleHook "orbs") }}
-  {{- range $orbsHook }}
-{{ toYaml . | indent 2 }}
-  {{- end }}
   ## <<Stencil::Block(CircleCIExtraOrbs)>>
 {{ file.Block "CircleCIExtraOrbs" }}
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestRenderAsOSSRepo-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAsOSSRepo-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -1,0 +1,170 @@
+(*codegen.File)(# Please re-run stencil after any changes to this file as invalid
+# syntax, such as anchors, will be fixed automatically.
+version: 2.1
+orbs:
+  shared: getoutreach/shared@2.30.0
+  queue: eddiewebb/queue@2.2.1
+  ## <<Stencil::Block(CircleCIExtraOrbs)>>
+
+  ## <</Stencil::Block>>
+
+parameters:
+  rebuild_cache:
+    type: boolean
+    default: false
+  ## <<Stencil::Block(CircleCIExtraParams)>>
+
+  ## <</Stencil::Block>>
+
+
+# Extra contexts to expose to all jobs below
+contexts: &contexts
+  - aws-credentials
+  - ghaccesstoken
+  - docker-registry
+  - npm-credentials
+  - box
+  - vault-dev
+  - confluence
+  - circleci-credentials
+  - tray-webhooks
+  - wizcli
+  ## <<Stencil::Block(extraContexts)>>
+  
+  ## <</Stencil::Block>>
+
+# Test configs to pass to test and cache jobs
+test: &test
+  context: *contexts
+  app_name: testing
+  ### Start parameters inserted by other modules
+  ### End parameters inserted by other modules
+  ## <<Stencil::Block(circleTestExtra)>>
+
+  ## <</Stencil::Block>>
+
+
+# Branches used for releasing code, pre-release or not
+release_branches: &release_branches
+  - "main"
+
+## <<Stencil::Block(circleAnchorExtra)>>
+
+## <</Stencil::Block>>
+
+jobs:  {} 
+  ## <<Stencil::Block(circleJobs)>>
+
+  ## <</Stencil::Block>>
+
+  ### Start jobs inserted by other modules
+  ### End jobs inserted by other modules
+
+workflows:
+  version: 2
+  ## <<Stencil::Block(circleWorkflows)>>
+
+  ## <</Stencil::Block>>
+
+  ### Start workflows inserted by other modules
+  ### End workflows inserted by other modules
+
+  rebuild-cache:
+    triggers:
+      - schedule:
+          # Every day at 00:00 UTC.
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - shared/save_cache: *test
+
+  manual-rebuild-cache:
+    when: << pipeline.parameters.rebuild_cache >>
+    jobs:
+      - shared/save_cache: *test
+
+  release:
+    when:
+      and:
+        - not: << pipeline.parameters.rebuild_cache >>
+    jobs:
+      ## <<Stencil::Block(circleWorkflowJobs)>>
+
+      ## <</Stencil::Block>>
+      ### Start jobs inserted by other modules
+      ### End jobs inserted by other modules
+      - shared/release: &release
+          dryrun: false
+          context: *contexts
+          ## <<Stencil::Block(circleReleaseExtra)>>
+
+          ## <</Stencil::Block>>
+          requires:
+            ## <<Stencil::Block(circleReleaseRequires)>>
+
+            ## <</Stencil::Block>>
+            - shared/test
+          filters:
+            branches:
+              only: main
+      # Dryrun for PRs
+      - shared/pre-release: &pre-release
+          dryrun: true
+          context: *contexts
+          ## <<Stencil::Block(circlePreReleaseDryRunExtra)>>
+
+          ## <</Stencil::Block>>
+          requires:
+            ## <<Stencil::Block(circlePreReleaseDryRunRequires)>>
+
+            ## <</Stencil::Block>>
+            - shared/test
+          filters:
+            branches:
+              ignore: *release_branches
+      - shared/test:
+          <<: *test
+          ## <<Stencil::Block(circleSharedTestExtra)>>
+
+          ## <</Stencil::Block>>
+      - shared/publish_docs:
+          context: *contexts
+          filters:
+            branches:
+              only:
+                - main
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/e2e:
+          context: *contexts
+          ## <<Stencil::Block(circleE2EExtra)>>
+
+          ## <</Stencil::Block>>
+      - shared/docker_stitch:
+          context: *contexts
+          requires:
+            - shared/docker_amd64
+            - shared/docker_arm64
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/docker_amd64:
+          context: *contexts
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+      - shared/docker_arm64:
+          context: *contexts
+          filters:
+            branches:
+              ignore: *release_branches
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -127,3 +127,12 @@ func TestRenderWithSkipE2eAndDocker(t *testing.T) {
 	})
 	st.Run(stenciltest.RegenerateSnapshots())
 }
+
+func TestRenderAsOSSRepo(t *testing.T) {
+	fakeDockerPullRegistry(t)
+	st := stenciltest.New(t, ".circleci/config.yml.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"oss": true,
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}


### PR DESCRIPTION
## What this PR does / why we need it

Avoid leaking registry URLs in public repositories.

Requires `devbase >= 2.31.0-rc.1`.

## Jira ID

[DT-4711]


[DT-4711]: https://outreach-io.atlassian.net/browse/DT-4711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ