### PR TITLE
fix: remove hardcoded ci-slim docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: stencil-circleci
-  docker_image: 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/bootstrap/ci-slim
   executor_name: testbed-docker-aws
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -192,7 +191,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: 182192988802.dkr.ecr.us-east-2.amazonaws.com/outreach-docker/bootstrap/ci-slim
           executor_name: testbed-docker-aws
           filters:
             branches:

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -63,7 +63,6 @@ test: &test
   context: *contexts
   app_name: {{ .Config.Name }}
   {{- if not (stencil.Arg "oss") }}
-  docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
   executor_name: {{ $executorName }}
   {{- end }}
   ### Start parameters inserted by other modules
@@ -207,7 +206,6 @@ workflows:
       - shared/test_node_client:
           context: *contexts
           {{- if not (stencil.Arg "oss") }}
-          docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
           executor_name: {{ $executorName }}
           {{- end }}
           steps:
@@ -286,7 +284,6 @@ workflows:
       - shared/publish_docs:
           context: *contexts
           {{- if not (stencil.Arg "oss") }}
-          docker_image: {{ .Runtime.Box.Docker.ImagePullRegistry }}/bootstrap/ci-slim
           executor_name: {{ $executorName }}
           {{- end }}
           filters:

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -40,7 +40,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -180,7 +179,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           filters:
             branches:

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,7 +37,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -134,7 +133,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           filters:
             branches:

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,7 +37,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -134,7 +133,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           filters:
             branches:

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,7 +37,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -100,7 +99,6 @@ workflows:
       ### End jobs inserted by other modules
       - shared/test_node_client:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
@@ -148,7 +146,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           filters:
             branches:

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -37,7 +37,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker-aws
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -100,7 +99,6 @@ workflows:
       ### End jobs inserted by other modules
       - shared/test_node_client:
           context: *contexts
-          docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker-aws
           steps:
             ## <<Stencil::Block(testNodeClientSteps)>>
@@ -148,7 +146,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.amazonaws.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker-aws
           filters:
             branches:

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -40,7 +40,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -165,7 +164,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           filters:
             branches:

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -40,7 +40,6 @@ contexts: &contexts
 test: &test
   context: *contexts
   app_name: testing
-  docker_image: registry.example.com/foo/bootstrap/ci-slim
   executor_name: testbed-docker
   ### Start parameters inserted by other modules
   ### End parameters inserted by other modules
@@ -165,7 +164,6 @@ workflows:
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts
-          docker_image: registry.example.com/foo/bootstrap/ci-slim
           executor_name: testbed-docker
           filters:
             branches:


### PR DESCRIPTION
## What this PR does / why we need it

It's preventing engineers from customizing the docker image to something else.

## Jira ID

[DT-4750]

[DT-4750]: https://outreach-io.atlassian.net/browse/DT-4750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ