### PR TITLE
fix: workflows.version is deprecated as of config version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -116,7 +116,6 @@ jobs: {{ if and (empty (file.Block "circleJobs")) (empty (stencil.GetModuleHook 
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 {{ file.Block "circleWorkflows" }}
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -68,7 +68,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -62,7 +62,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForDisabledPrereleaseWithAutoPrerelease-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -62,7 +62,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClient-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -62,7 +62,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestConfigForLibraryWithNodeJSGRPCClientAndECR-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -62,7 +62,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAFile-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -68,7 +68,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestRenderAsOSSRepo-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderAsOSSRepo-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -61,7 +61,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>

--- a/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
+++ b/templates/.snapshots/TestRenderWithSkipE2eAndDocker-.circleci-config.yml.tpl-.circleci-config.yml.snapshot
@@ -68,7 +68,6 @@ jobs:  {}
   ### End jobs inserted by other modules
 
 workflows:
-  version: 2
   ## <<Stencil::Block(circleWorkflows)>>
 
   ## <</Stencil::Block>>


### PR DESCRIPTION
## What this PR does / why we need it

The CircleCI extension in VSCode says:

> Version key is deprecated since 2.1

The [docs](https://circleci.com/docs/configuration-reference/#workflow-version) say:

> The workflows `version` key is **not** required for `version: 2.1` configuration

## Jira ID

[DT-4752]

[DT-4752]: https://outreach-io.atlassian.net/browse/DT-4752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ