### PR TITLE
test: simplify registry test helpers

### DIFF
--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"maps"
-	"os"
 	"testing"
 
 	"github.com/getoutreach/stencil/pkg/configuration"

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -13,22 +13,14 @@ import (
 // variable to a fake value for the duration of the test.
 func fakeDockerPullRegistry(t *testing.T) {
 	t.Helper()
-	oldRegistryValue := os.Getenv("BOX_DOCKER_PULL_IMAGE_REGISTRY")
-	os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", "registry.example.com/foo")
-	t.Cleanup(func() {
-		os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", oldRegistryValue)
-	})
+	t.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", "registry.example.com/foo")
 }
 
 // fakeECRPullRegistry sets the BOX_DOCKER_PULL_IMAGE_REGISTRY environment
 // variable to a fake ECR value for the duration of the test.
 func fakeECRPullRegistry(t *testing.T) {
 	t.Helper()
-	oldRegistryValue := os.Getenv("BOX_DOCKER_PULL_IMAGE_REGISTRY")
-	os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", "registry.example.amazonaws.com/foo")
-	t.Cleanup(func() {
-		os.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", oldRegistryValue)
-	})
+	t.Setenv("BOX_DOCKER_PULL_IMAGE_REGISTRY", "registry.example.amazonaws.com/foo")
 }
 
 // setTestArgs is a helper function to set arguments for the stencil test.


### PR DESCRIPTION
## What this PR does / why we need it

Was likely written before I realized `testing.T#Setenv` already existed.