### PR TITLE
fix: lock circleci tool version

### DIFF
--- a/templates/mise.toml.tpl
+++ b/templates/mise.toml.tpl
@@ -6,7 +6,7 @@
 {{- end }}
 
 {{- define "miseOrbTools" }}
-- circleci: latest
+- circleci: "0.1.34950"
 {{- end }}
 
 {{- if stencil.Arg "releaseOptions.publishOrb" }}


### PR DESCRIPTION
## What this PR does / why we need it

Avoids a bug with stale lockfile entries with `mise lock` and "latest" tool versions.

## Jira ID

[DT-5280]

[DT-5280]: https://outreach-io.atlassian.net/browse/DT-5280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

